### PR TITLE
Remove map icon when it's too small for optimization and add icons to filter 

### DIFF
--- a/maps/src/CustomMarker.tsx
+++ b/maps/src/CustomMarker.tsx
@@ -15,7 +15,7 @@ function DataItem({ text, value }: { text: string, value: string }) {
   )
 }
 
-export default function CustomMarker({ item, radius: size } : { item: MarkerData['map_data'][any], radius: number }) {
+export default function CustomMarker({ item, size } : { item: MarkerData['map_data'][any], size: number }) {
   return (
     <Marker
       icon={getIcon(item.type, size)}

--- a/maps/src/Map.tsx
+++ b/maps/src/Map.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@mui/system';
 import { CheckCircleOutline, CircleOutlined, ExpandCircleDown, Search as SearchIcon } from '@mui/icons-material';
 import React, { useEffect, useMemo, useState } from 'react';
 import { CircleMarker, MapContainer, Popup, TileLayer, useMap, useMapEvents } from 'react-leaflet';
-import {SimpleMapScreenshoter} from 'leaflet-simple-map-screenshoter'
+import { SimpleMapScreenshoter } from 'leaflet-simple-map-screenshoter';
 import { MarkerData, useMarkers } from './hooks';
 import CustomMarker from './CustomMarker';
 import { DataType, dataTypeToColor, dataTypeToLabel } from './utils/DataType';
@@ -12,17 +12,18 @@ import "./Map.css"
 import { buildSearchIndex, filterMultipleTypes, searchText } from './utils/filters';
 
 const INITIAL_ZOOM = 15;
-const getZoom = (zoom: number) => Math.max(zoom ** 1.7 / 2, 32);
+const MINIMUM_ICON_SIZE = 24;
+const getIconSize = (zoom: number) => Math.max(zoom ** 1.7 / 2, MINIMUM_ICON_SIZE);
 
 const BASE_LOCATION: [number, number] = [37.57713668904397, 36.92937651365644];
 
 function Markers({ filteredData, selfLocation }: { filteredData: MarkerData["map_data"], selfLocation: [number, number] | null }){
-  const [radius, setRadius] = useState(getZoom(useMap().getZoom()));
+  const [size, setSize] = useState(getIconSize(useMap().getZoom()));
   const [bounds, setBounds] = useState(useMap().getBounds());
 
   const mapEvents = useMapEvents({
     zoomend: () => {
-      setRadius(getZoom(mapEvents.getZoom()));
+      setSize(getIconSize(mapEvents.getZoom()));
       setBounds(mapEvents.getBounds());
     },
     moveend: () => {
@@ -47,7 +48,7 @@ function Markers({ filteredData, selfLocation }: { filteredData: MarkerData["map
         <CustomMarker
           key={`item-${i}`}
           item={item}
-          radius={radius}
+          size={size}
         />
       ))}
 
@@ -59,7 +60,7 @@ function Markers({ filteredData, selfLocation }: { filteredData: MarkerData["map
           color="white"
           fillColor={"#4F81E6"}
           fillOpacity={1}
-          radius={radius / 4}
+          radius={size / 4}
           opacity={0.75}
         >
           <Popup>Sizin Konumunuz</Popup>

--- a/maps/src/Map.tsx
+++ b/maps/src/Map.tsx
@@ -7,9 +7,10 @@ import { SimpleMapScreenshoter } from 'leaflet-simple-map-screenshoter';
 import { MarkerData, useMarkers } from './hooks';
 import CustomMarker from './CustomMarker';
 import { DataType, dataTypeToColor, dataTypeToLabel } from './utils/DataType';
+import { buildSearchIndex, filterMultipleTypes, searchText } from './utils/filters';
+import { dataTypeToSVG } from './svgs';
 
 import "./Map.css"
-import { buildSearchIndex, filterMultipleTypes, searchText } from './utils/filters';
 
 const INITIAL_ZOOM = 15;
 const MINIMUM_ICON_SIZE = 24;
@@ -206,8 +207,20 @@ export default function Map() {
                         {dataTypes.includes(type)
                           ? <CheckCircleOutline style={{ color: 'white' }} />
                           : <CircleOutlined style={{ color: 'white' }} />}
-                        <Typography variant="body1" component="span" sx={{ ml: 1 }}>
+                        <Typography variant="body1" component="span" sx={{ 
+                          ml: 1,
+                          mr: 1,
+                          display: 'flex'
+                        }}>
                           {dataTypeToLabel[type].name_tr}
+                          <div style={{
+                            height: '22.5px',
+                            width: '22.5px',
+                            fill: 'white',
+                            marginLeft: '8px',
+                          }}
+                            dangerouslySetInnerHTML={{ __html: dataTypeToSVG[type] }}
+                          />
                         </Typography>
                     </div>
                 ))}

--- a/maps/src/utils/icon.ts
+++ b/maps/src/utils/icon.ts
@@ -2,6 +2,7 @@ import L from 'leaflet';
 import { dataTypeToSVG, MARKER_SVG } from '../svgs';
 import { dataTypeToColor } from './DataType';
 
+const RENDER_ICON_SIZE_LIMIT = 28;
 
 function SVG(svg: any, size: number, markerColour: string) {
   return (
@@ -18,9 +19,11 @@ function SVG(svg: any, size: number, markerColour: string) {
       >
         ${MARKER_SVG}
       </div>
-      ${svg ? `<div style="fill: white; position: absolute; height: ${size / 2}px; width: ${size / 2}px; left: ${size / 4}px; top: ${size / 8}px;">
-        ${svg}
-      </div>` : ""}
+      ${svg && size > RENDER_ICON_SIZE_LIMIT 
+        ? `<div style="fill: white; position: absolute; height: ${size / 2}px; width: ${size / 2}px; left: ${size / 4}px; top: ${size / 8}px;">
+          ${svg}
+        </div>` 
+        : ""}
     </div>`
   )
 }


### PR DESCRIPTION
1-
I think they are still identifiable with their colors and this would be slight optimization.
<img width="785" alt="image" src="https://user-images.githubusercontent.com/34626070/218311921-4eeddfa0-c8ad-4ac9-a40c-1d9c3f1396f2.png">
2- 
<img width="293" alt="image" src="https://user-images.githubusercontent.com/34626070/218311908-7ef7cd0c-2288-4cd8-9374-d58c366e8fa9.png">
