### PR TITLE
Create a generic `Title` component

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -152,7 +152,7 @@ const App = () => {
         </Box>
       </Box>
 
-      <Container sx={{ mt: 1 }}>
+      <Container sx={{ mt: 3 }}>
         <Routes>
           <Route path='/*' element={<RootQuestion />} />
           <Route path='/about' element={<AboutUs />} />

--- a/fe/src/components/AboutUs.tsx
+++ b/fe/src/components/AboutUs.tsx
@@ -6,7 +6,7 @@ export default function AboutUs() {
   const { t } = useTranslation();
 
   return (
-    <Box sx={{ paddingTop: 4 }}>
+    <Box>
       <Container maxWidth="sm" sx={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
         <Typography variant="h3" align="center" sx={{mt: 4}}>
             {t('page.about.title')}

--- a/fe/src/components/Data.tsx
+++ b/fe/src/components/Data.tsx
@@ -68,8 +68,7 @@ export default function Data({ dataNode }: { dataNode: DataNode }) {
         display: 'flex',
         flexFlow: 'column nowrap',
         justifyContent: 'center',
-        alignItems: 'center',
-        paddingBottom: '50px',
+        alignItems: 'center'
       }}
     >
       {renderData()}

--- a/fe/src/components/Question.tsx
+++ b/fe/src/components/Question.tsx
@@ -48,17 +48,15 @@ export default function Question({ paths }: { paths: string[] }) {
 
   if (!selectedNode) {
     return (
-      <Box>
-        <Box
-          sx={{
-            textAlign: 'center',
-            display: 'flex',
-            flexFlow: 'column nowrap',
-            justifyContent: 'center',
-          }}
-        >
-          <Typography variant='h4'>{t('notFound')}</Typography>
-        </Box>
+      <Box
+        sx={{
+          textAlign: 'center',
+          display: 'flex',
+          flexFlow: 'column nowrap',
+          justifyContent: 'center',
+        }}
+      >
+        <Typography variant='h4'>{t('notFound')}</Typography>
       </Box>
     );
   }
@@ -125,13 +123,13 @@ export default function Question({ paths }: { paths: string[] }) {
           direction={{ xs: 'column', sm: 'row' }}
           justifyContent='center'
           alignItems='center'
-          divider={<Divider orientation='vertical' flexItem sx={{ mt: 5 }} />}
+          divider={<Divider orientation='vertical' flexItem />}
           sx={{
             display: 'flex',
             flexFlow: 'row wrap',
             alignItems: 'start',
             justifyContent: 'center',
-            paddingTop: '50px',
+            mt: 2,
           }}
         >
           {Object.keys(buttonsByCategories)
@@ -144,7 +142,7 @@ export default function Question({ paths }: { paths: string[] }) {
                   display: 'flex',
                   flexFlow: 'column nowrap',
                   justifyContent: 'center',
-                  paddingTop: '50px',
+                  mb: 2
                 }}
               >
                 <Typography variant='h5'>
@@ -158,13 +156,14 @@ export default function Question({ paths }: { paths: string[] }) {
     }
     return getAutocompleteName(selectedNode, i18n.language) ? (
       <Autocomplete
+        sx={{ m: 2 }}
         id='options-autocomplete'
         renderInput={(params) => (
           <TextField
             {...params}
             label={getAutocompleteName(selectedNode, i18n.language)}
             variant='outlined'
-            sx={{ minWidth: '200px', m: 2 }}
+            sx={{ minWidth: '240px' }}
           />
         )}
         options={selectedNode.options}
@@ -195,7 +194,7 @@ export default function Question({ paths }: { paths: string[] }) {
   };
 
   return (
-    <Box>
+    <>
       <Box
         sx={{
           textAlign: 'center',
@@ -204,7 +203,7 @@ export default function Question({ paths }: { paths: string[] }) {
           justifyContent: 'center',
         }}
       >
-        <Typography variant='h4'>
+        <Typography variant='h5'>
           {selectedNode[`text_${i18n.language}`] || selectedNode.text}
         </Typography>
 
@@ -214,13 +213,13 @@ export default function Question({ paths }: { paths: string[] }) {
             flexFlow: 'row wrap',
             alignItems: 'start',
             justifyContent: 'center',
-            paddingBottom: '50px',
+            mt: 2
           }}
         >
           {renderOptions()}
           {selectedNode.externalData?.usefulLinks?.length > 0 && (
-            <Box width='100%' mt={8}>
-              <Typography variant='h4'>
+            <Box width='100%' mt={2}>
+              <Typography variant='h5' sx={{ mb: 2 }}>
                 {selectedNode.externalData[`text_${i18n.language}`] ||
                   selectedNode.externalData.text}
               </Typography>
@@ -229,6 +228,6 @@ export default function Question({ paths }: { paths: string[] }) {
           )}
         </Box>
       </Box>
-    </Box>
+    </>
   );
 }

--- a/fe/src/components/Title.tsx
+++ b/fe/src/components/Title.tsx
@@ -1,0 +1,15 @@
+import { Alert, Typography } from "@mui/material";
+
+export default function Title({ title, subtitle, severity = 'warning' }: { title: string, subtitle?: string, severity?: 'info' | 'warning' | 'error' | 'success'}) {
+  
+  return (
+    <>
+      <Typography variant='h5' sx={{ mb: 2}}>
+        {title}
+      </Typography>
+      {subtitle && <Alert severity={severity} sx={{ mb: 2, textAlign: 'start' }}>
+        {subtitle}
+      </Alert>}
+    </>
+  )
+} 

--- a/fe/src/components/data/ArticleData.tsx
+++ b/fe/src/components/data/ArticleData.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ArticleDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 /* const ArticleLanguageHelper = ({
   item,
@@ -66,11 +67,11 @@ export default function ArticleData({ value }: { value: ArticleDataNode }) {
   const { t } = useTranslation();
   return (
     <Box>
-      <h3>{t('data.important_articles.title')}</h3>
-
-      <p>
-        <b>{t('data.important_articles.subtitle')}</b>
-      </p>
+      <Title
+        title={t('data.important_articles.title')}
+        subtitle={t('data.important_articles.subtitle') || ''}
+        severity='info'
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650 }}>
         <Table sx={{ maxWidth: 650 }} aria-label='simple table'>
           <TableHead>

--- a/fe/src/components/data/CityAccommodation.tsx
+++ b/fe/src/components/data/CityAccommodation.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { CityAccommodationNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function CityAccommodation({
   value,
@@ -19,14 +20,12 @@ export default function CityAccommodation({
   const { t } = useTranslation();
   return (
     <Box>
-      <h3>
-        {t('data.city_accommodation.title', {
+      <Title
+        title={t('data.city_accommodation.title', {
           city: value.city,
         })}
-      </h3>
-      <p>
-        <b>{t('data.city_accommodation.subtitle')}</b>
-      </p>
+        subtitle={t('data.city_accommodation.subtitle') || ""}
+      />
       {/* // TO-DO: https://react.i18next.com/latest/trans-component */}
       <TableContainer component={Paper} >
         <Table >

--- a/fe/src/components/data/ContainerPharmacyData.tsx
+++ b/fe/src/components/data/ContainerPharmacyData.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ContainerPharmacyDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function ContainerPharmacyData({
   value,
@@ -26,7 +27,9 @@ export default function ContainerPharmacyData({
   value.items.sort((a, b) => a.city.localeCompare(b.city));
   return (
     <Box>
-      <h3>{t('data.container_pharmacy')}</h3>
+      <Title
+        title={t('data.container_pharmacy')}
+      />
       {isMinWidth ? (
         <List>
           {value.items.map((item, i) => (

--- a/fe/src/components/data/DonationLinksData.tsx
+++ b/fe/src/components/data/DonationLinksData.tsx
@@ -10,15 +10,17 @@ import {
   } from '@mui/material';
   import { useTranslation } from 'react-i18next';
   import { DonationLinksDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
   
   export default function DonationLinksData({ value }: { value: DonationLinksDataNode }) {
     const { t } = useTranslation();
     return (
       <Box>
-        <h3>{t('data.donation.title')}</h3>
-        <p>
-          <b>{t('data.donation.subtitle')}</b>
-        </p>
+        <Title
+          title={t('data.donation.title')}
+          subtitle={t('data.donation.subtitle') || ""}
+          severity="success"
+        />
         <TableContainer component={Paper} sx={{ maxWidth: 650 }}>
           <Table sx={{ maxWidth: 650 }} aria-label='simple table'>
             <TableHead>

--- a/fe/src/components/data/EvacuationData.tsx
+++ b/fe/src/components/data/EvacuationData.tsx
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from 'react-i18next';
 
 import { EvacuationDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function EvacuationData({
   value,
@@ -27,9 +28,9 @@ export default function EvacuationData({
   value.items.sort((a, b) => a.city.localeCompare(b.city));
   return (
     <Box>
-      <h3>
-        {t('data.evacuation_points.title', { city: value.items[0].city })}
-      </h3>
+      <Title
+        title={t('data.evacuation_points.title', { city: value.items[0].city })}
+      />
       {isMinWidth ? (
         <List>
           {value.items.map((item, i) => (

--- a/fe/src/components/data/FoodDistributionData.tsx
+++ b/fe/src/components/data/FoodDistributionData.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { FoodDistributionDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function FoodDistributionData({
   value,
@@ -21,17 +22,15 @@ export default function FoodDistributionData({
   return (
     <Box
       sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
-    >
-      <h3>
-        {t('data.food_distribution.title', {
+  >
+      <Title
+        title={t('data.food_distribution.title', {
           city: value.city,
           county: value.county,
         })}
-      </h3>
-
-      <p>
-        <b>{t('data.food_distribution.subtitle')}</b>
-      </p>
+        subtitle={t('data.food_distribution.subtitle') || ""}
+        severity='warning'
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650, minWidth: 100 }}>
         <Table sx={{ maxWidth: 650, minWidth: 100 }}>
           <TableHead>

--- a/fe/src/components/data/GasStationsData.tsx
+++ b/fe/src/components/data/GasStationsData.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { GasStationsDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function GasStationsData({
   value,
@@ -25,12 +26,12 @@ export default function GasStationsData({
   const isMinWidth = useMediaQuery('(max-width:600px)');
   return (
     <Box>
-      <h3>
-        {t('data.gas_stations.title', {
+      <Title
+        title={t('data.gas_stations.title', {
           city: value.city,
           county: value.county,
         })}
-      </h3>
+      />
       {isMinWidth ? (
         <List>
           {value.items.map((item, i) => (

--- a/fe/src/components/data/GatheringData.tsx
+++ b/fe/src/components/data/GatheringData.tsx
@@ -11,17 +11,18 @@ import {
 } from '@mui/material';
 
 import { GatheringDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function GatheringData({ value }: { value: GatheringDataNode }) {
   const { t } = useTranslation();
 
   return (
     <Box>
-      <h3>
-        {t('data.gathering.title', {
+      <Title
+        title={t('data.gathering.title', {
           city: value.city,
         })}
-      </h3>
+      />
 
       <TableContainer component={Paper} sx={{ maxWidth: 650 }}>
         <Table sx={{ maxWidth: 650 }} aria-label='simple table'>

--- a/fe/src/components/data/HelpItemData.tsx
+++ b/fe/src/components/data/HelpItemData.tsx
@@ -1,6 +1,7 @@
 import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { HelpItemNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 /* const HelpItemLanguageHelper = ({
   item,
@@ -81,11 +82,11 @@ export default function HelpItemData({ value }: { value: HelpItemNode }) {
   const { t } = useTranslation();
   return (
     <Box>
-      <h3>
-        {t('data.help_item.title', {
+      <Title
+        title={t('data.help_item.title', {
           city: value.city,
         })}
-      </h3>
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650, minWidth: 100 }}>
         <Table sx={{ maxWidth: 650, minWidth: 100 }}>
           <TableHead>

--- a/fe/src/components/data/PhoneData.tsx
+++ b/fe/src/components/data/PhoneData.tsx
@@ -10,12 +10,15 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { TelephoneDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function TelephoneData({ value }: { value: TelephoneDataNode }) {
   const { t } = useTranslation();
   return (
     <Box>
-      <h3>{t('data.important_phone_numbers.title')}</h3>
+      <Title
+        title={t('data.important_phone_numbers.title')}
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650 }}>
         <Table sx={{ maxWidth: 650 }} aria-label='simple table'>
           <TableHead>

--- a/fe/src/components/data/SahraData.tsx
+++ b/fe/src/components/data/SahraData.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { SahraDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 /* const detailedInfo = (t: TFunction, phone_number?: string, url?: string) => {
   if (!phone_number && !url) {
@@ -75,11 +76,11 @@ export default function SahraDistributionData({
   const { t } = useTranslation();
   return (
     <Box>
-      <h3>
-        {t('data.health_services.title', {
+      <Title
+        title={t('data.health_services.title', {
           city: value.city,
         })}
-      </h3>
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650, minWidth: 100 }}>
         <Table sx={{ maxWidth: 650, minWidth: 100 }}>
           <TableHead>

--- a/fe/src/components/data/StemCellData.tsx
+++ b/fe/src/components/data/StemCellData.tsx
@@ -10,12 +10,15 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { StemCellDataNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 export default function StemCellData({ value }: { value: StemCellDataNode }) {
   const { t } = useTranslation();
   return (
     <Box>
-      <h3>{t('data.stem_cell.title')}</h3>
+      <Title
+        title={t('data.stem_cell.title')}
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650 }}>
         <Table sx={{ maxWidth: 650 }}>
           <TableHead>

--- a/fe/src/components/data/TransportationsData.tsx
+++ b/fe/src/components/data/TransportationsData.tsx
@@ -1,7 +1,22 @@
-import { Paper, Box, TableContainer, Table, TableRow, TableCell, CardContent, Card, TableHead, TableBody, useMediaQuery, List, ListItem } from '@mui/material';
+import { 
+  Paper,
+  Box,
+  TableContainer,
+  Table,
+  TableRow,
+  TableCell,
+  CardContent,
+  Card,
+  TableHead,
+  TableBody,
+  useMediaQuery,
+  List,
+  ListItem
+} from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 import { TransportationDataNode } from "../../interfaces/TreeNode";
+import Title from '../Title';
 
 const getValidityDateExplanation = (t: any, date: string) => {
   if (!date) return '';
@@ -14,7 +29,9 @@ export default function TransportationsData({ value } : {value: TransportationDa
 
   return (
     <Box>
-      <h3>{t('data.transportation.title')}</h3>
+      <Title
+        title={t('data.transportation.title')}
+      />
       {isMinWidth ? <List>
         {value.transportations.map((item) => (
           <ListItem key={item.name}>

--- a/fe/src/components/data/UsefulLinksdata.tsx
+++ b/fe/src/components/data/UsefulLinksdata.tsx
@@ -7,6 +7,8 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  Typography,
+  Alert,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { UsefulLinksDataNode } from '../../interfaces/TreeNode';
@@ -74,13 +76,15 @@ export default function UsefulLinksData({
     <Box>
       {!noTitle && (
         <>
-          <h3>{t('data.important_web_sites.title')}</h3>
-
-          <p>
-            <b>{t('data.important_web_sites.subtitle')}</b>
-          </p>
+          <Typography variant='h5'>
+            {t('data.important_web_sites.title')}
+          </Typography>
+          <Alert severity='info' sx={{ mt: 2, mb: 2, textAlign: 'start' }}>
+            {t('data.important_web_sites.subtitle')}
+          </Alert>
         </>
       )}
+      
       <TableContainer component={Paper} >
         <Table >
           <TableHead>

--- a/fe/src/components/data/VetData.tsx
+++ b/fe/src/components/data/VetData.tsx
@@ -1,5 +1,6 @@
 import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';import { useTranslation } from 'react-i18next';
 import { VetNode } from '../../interfaces/TreeNode';
+import Title from '../Title';
 
 /* const VetLanguageHelper = ({ item, index }: { item: Vet; index: number }) => {
   const { i18n } = useTranslation();
@@ -67,11 +68,12 @@ export default function VetData({ value }: { value: VetNode }) {
 
   return (
     <Box display='flex' flexDirection='column' alignItems='center'>
-      <h3>{t('data.veterinary.title', { city: value.city })}</h3>
-
-      <p>
-        <b>{t('data.veterinary.subtitle')}</b>
-      </p>
+      <Title
+        title={t('data.veterinary.title', {
+          city: value.city,
+        })}
+        subtitle={t('data.veterinary.subtitle') || ""}
+      />
       <TableContainer component={Paper} sx={{ maxWidth: 650, minWidth: 100 }}>
         <Table sx={{ maxWidth: 650, minWidth: 100 }}>
           <TableHead>


### PR DESCRIPTION
This PR creates a generic `Title` component that includes a subtitle as an Alert box from mui 
<img width="398" alt="image" src="https://user-images.githubusercontent.com/34626070/218341101-907d9e1e-77ef-4d1c-ab4f-4019d8707b51.png">

This PR also removes some padding from the top of the main page.

prev:
<img width="395" alt="image" src="https://user-images.githubusercontent.com/34626070/218341171-e4bf4726-cdf1-41c1-94e0-4449f066e3b7.png">

now:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/34626070/218341166-da1891e5-76d5-476f-a97b-239dd9cf556b.png">
  

